### PR TITLE
Handle ConversionError from Schematics in SchematicsModelField

### DIFF
--- a/stereotype/contrib/schematics.py
+++ b/stereotype/contrib/schematics.py
@@ -1,18 +1,31 @@
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Optional, Type, cast, Iterable
 
 try:
     # Schematics 2
-    from schematics.exceptions import CompoundError as SchematicsValidationError
+    from schematics.exceptions import (
+        CompoundError as SchematicsValidationError,
+        DataError as SchematicsConversionError,
+    )
 except ImportError:  # pragma: no cover
     # Schematics 1
-    from schematics.exceptions import ValidationError as SchematicsValidationError
+    from schematics.exceptions import (
+        ValidationError as SchematicsValidationError,
+        ModelConversionError as SchematicsConversionError,
+    )
 from schematics.models import Model as SchematicsModel
 
 from stereotype.fields.annotations import AnnotationResolver
 from stereotype.fields.model import ModelField
 from stereotype.roles import DEFAULT_ROLE, Role
-from stereotype.utils import Missing, ValidationContextType, PathErrorType, ToPrimitiveContextType
+from stereotype.utils import (
+    Missing,
+    ValidationContextType,
+    PathErrorType,
+    ToPrimitiveContextType,
+    ConversionError,
+)
 
 
 class SchematicsModelField(ModelField):
@@ -27,10 +40,20 @@ class SchematicsModelField(ModelField):
     :param to_primitive_name: Changes the key used to represent the field in serialized data - output only
     """
 
-    def __init__(self, *, default: Any = Missing, hide_none: bool = False,
-                 primitive_name: Optional[str] = Missing, to_primitive_name: Optional[str] = Missing):
-        super().__init__(default=default, hide_none=hide_none,
-                         primitive_name=primitive_name, to_primitive_name=to_primitive_name)
+    def __init__(
+        self,
+        *,
+        default: Any = Missing,
+        hide_none: bool = False,
+        primitive_name: Optional[str] = Missing,
+        to_primitive_name: Optional[str] = Missing
+    ):
+        super().__init__(
+            default=default,
+            hide_none=hide_none,
+            primitive_name=primitive_name,
+            to_primitive_name=to_primitive_name,
+        )
 
         self.type: Type[SchematicsModel] = cast(Type[SchematicsModel], NotImplemented)
 
@@ -39,12 +62,14 @@ class SchematicsModelField(ModelField):
             raise parser.incorrect_type(self)
         self.type = parser.annotation
 
-    def validate(self, value: SchematicsModel, context: ValidationContextType) -> Iterable[PathErrorType]:
+    def validate(
+        self, value: SchematicsModel, context: ValidationContextType
+    ) -> Iterable[PathErrorType]:
         try:
             value.validate()  # Cannot propagate the context to schematics
         except SchematicsValidationError as e:
             # to_primitive works for Schematics 2, messages for Schematics 1
-            messages = e.to_primitive() if hasattr(e, 'to_primitive') else e.messages
+            messages = e.to_primitive() if hasattr(e, "to_primitive") else e.messages
             yield from _iterate_validation_errors(messages)
 
     def copy_value(self, value: Any) -> Any:
@@ -52,12 +77,23 @@ class SchematicsModelField(ModelField):
             return value
         return deepcopy(value)
 
-    def to_primitive(self, value: Any, role: Role = DEFAULT_ROLE, context: ToPrimitiveContextType = None) -> Any:
+    def to_primitive(
+        self,
+        value: Any,
+        role: Role = DEFAULT_ROLE,
+        context: ToPrimitiveContextType = None,
+    ) -> Any:
         if value is None or value is Missing:
             return value
         role_str = role.name if role is not DEFAULT_ROLE else None
         value: SchematicsModel
         return value.to_primitive(role_str, context)
+
+    def convert(self, value):
+        try:
+            return super().convert(value)
+        except SchematicsConversionError as e:
+            raise_conversion_error(e)
 
 
 def _iterate_validation_errors(messages: dict) -> Iterable[PathErrorType]:
@@ -68,3 +104,33 @@ def _iterate_validation_errors(messages: dict) -> Iterable[PathErrorType]:
         else:
             for path, error in _iterate_validation_errors(container):
                 yield (str(key),) + path, error
+
+
+def raise_conversion_error(error):
+    items = list(error.messages.items())
+    path = []
+    try_raise_conversion_error = (
+        _try_raise_conversion_error_stereotype_1
+        if isinstance(error, TypeError)
+        else _try_raise_conversion_error_stereotype_2
+    )
+
+    while len(items) > 0:
+        items_tuple = items[0]
+        primitive_name = items_tuple[0]
+        path.append(primitive_name)
+        values = items_tuple[1]
+        try_raise_conversion_error(values, path)
+        items = list(values.items())
+
+
+def _try_raise_conversion_error_stereotype_1(values, path):
+    if not isinstance(values, dict):
+        message = values[0]
+        raise ConversionError.new(message, *path)
+
+
+def _try_raise_conversion_error_stereotype_2(values, path):
+    if not isinstance(values, Mapping):
+        message = str(values.messages[0])
+        raise ConversionError.new(message, *path)

--- a/tests/contrib/test_schematics.py
+++ b/tests/contrib/test_schematics.py
@@ -280,25 +280,3 @@ class TestSchematicsModelField(TestCase):
             {"otter": {"recursive": {"bool": ["Must be either true or false."]}}},
             ctx.exception.errors,
         )
-
-    def test_test(self):
-        from stereotype import (
-            Model,
-            ConversionError,
-            ModelField,
-            IntField,
-        )
-
-        class A(Model):
-            x: int = IntField()
-
-        class B(Model):
-            a: A = ModelField()
-
-        class C(Model):
-            b: B = ModelField
-
-        with self.assertRaises(ConversionError) as ctx:
-            C({"b": B({"a": A({"x": ""})})})
-
-        print()

--- a/tests/contrib/test_schematics.py
+++ b/tests/contrib/test_schematics.py
@@ -9,22 +9,33 @@ from schematics.transforms import blacklist, whitelist
 from schematics.types import IntType, StringType, FloatType, BooleanType
 from schematics.types.compound import ModelType, ListType
 
-from stereotype import Model, StrField, Missing, Role, ValidationError, RequestedRoleFields, ConfigurationError
+from stereotype import (
+    Model,
+    StrField,
+    Missing,
+    Role,
+    ValidationError,
+    RequestedRoleFields,
+    ConfigurationError,
+    ConversionError,
+)
 from stereotype.contrib.schematics import SchematicsModelField
 
 
-ROLE_X = Role('x')
-ROLE_Y = Role('y')
+ROLE_X = Role("x")
+ROLE_Y = Role("y")
 
 
 class Inner(SchematicsModel):
-    stuff = ListType(FloatType(required=True, max_value=7.), required=True, default=list, max_size=2)
+    stuff = ListType(
+        FloatType(required=True, max_value=7.0), required=True, default=list, max_size=2
+    )
     bool = BooleanType(required=True)
 
     def to_primitive(self, role=None, context=None):
         data = super().to_primitive(role, context)
-        if context is not None and context.get('private', False):
-            data['stuff'] = '<hidden>'
+        if context is not None and context.get("private", False):
+            data["stuff"] = "<hidden>"
         return data
 
     def __deepcopy__(self, memodict=None):
@@ -32,20 +43,22 @@ class Inner(SchematicsModel):
         return self.__class__(self.to_primitive())
 
     def __repr__(self):
-        return '<Inner>'
+        return "<Inner>"
 
     class Options:
         roles = {
-            ROLE_X.name: blacklist('stuff'),
-            ROLE_Y.name: whitelist('stuff'),
+            ROLE_X.name: blacklist("stuff"),
+            ROLE_Y.name: whitelist("stuff"),
         }
 
 
 class Root(Model):
-    number: float = 42.
+    number: float = 42.0
     string: str = StrField(min_length=3)
     inner: Inner = SchematicsModelField(default=Inner)
-    outer: Optional[Outer] = SchematicsModelField(hide_none=True, primitive_name='otter')
+    outer: Optional[Outer] = SchematicsModelField(
+        hide_none=True, primitive_name="otter"
+    )
 
     @classmethod
     def declare_roles(cls) -> Iterable[RequestedRoleFields]:
@@ -54,13 +67,13 @@ class Root(Model):
 
 class Outer(SchematicsModel):
     integer = IntType(required=True)
-    string = StringType(required=False, default="def", choices=['str', 'ing'])
+    string = StringType(required=False, default="def", choices=["str", "ing"])
     recursive = ModelType(Inner)
 
     @staticmethod
     def validate_integer(value, _):
         if value % 2:
-            raise ValueError('Must be even')
+            raise ValueError("Must be even")
 
     def __deepcopy__(self, memodict=None):
         # Works around the fact that deep copy doesn't work in Schematics 2
@@ -69,7 +82,7 @@ class Outer(SchematicsModel):
     class Options:
         roles = {
             ROLE_X.name: blacklist(),
-            ROLE_Y.name: whitelist('integer', 'recursive'),
+            ROLE_Y.name: whitelist("integer", "recursive"),
         }
 
 
@@ -78,102 +91,214 @@ class TestSchematicsModelField(TestCase):
         root = Root()
         self.assertEqual(Inner(), root.inner)
         self.assertIs(Missing, root.outer)
-        self.assertEqual({'inner': {'bool': None, 'stuff': []}, 'number': 42.0}, root.serialize())
+        self.assertEqual(
+            {"inner": {"bool": None, "stuff": []}, "number": 42.0}, root.serialize()
+        )
         self.assertEqual(root.copy(deep=True), root)
-        self.assertEqual('<Root {number=42.0, string=Missing, inner=<Inner>, outer=Missing}>', repr(root))
+        self.assertEqual(
+            "<Root {number=42.0, string=Missing, inner=<Inner>, outer=Missing}>",
+            repr(root),
+        )
 
     def test_none_value(self):
-        root = Root({'inner': None, 'otter': None})
+        root = Root({"inner": None, "otter": None})
         self.assertIsNone(root.inner)
         self.assertIsNone(root.outer)
-        self.assertEqual({'inner': None, 'number': 42.0}, root.serialize())
+        self.assertEqual({"inner": None, "number": 42.0}, root.serialize())
         self.assertEqual(root.copy(deep=True), root)
         with self.assertRaises(ValidationError) as e:
             root.validate()
-        self.assertEqual({
-            'inner': ['This field is required'],
-            'string': ['This field is required'],
-        }, e.exception.errors)
+        self.assertEqual(
+            {
+                "inner": ["This field is required"],
+                "string": ["This field is required"],
+            },
+            e.exception.errors,
+        )
 
     def test_full(self):
-        root = Root({
-            'number': 47,
-            'string': False,
-            'inner': {'stuff': [1, 2, 3], 'bool': 1},
-            'otter': {'integer': '7', 'string': 1, 'recursive': {'stuff': [1., 2., 3.]}},
-        })
-        self.assertEqual(Inner({'stuff': [1, 2, 3], 'bool': True}), root.inner)
-        self.assertEqual('1', root.outer.string)
-        self.assertEqual({
-            'number': 47.,
-            'string': 'False',
-            'inner': {'stuff': [1., 2., 3.], 'bool': True},
-            'otter': {'integer': 7, 'string': '1', 'recursive': {'stuff': [1., 2., 3.], 'bool': None}},
-        }, root.to_primitive())
+        root = Root(
+            {
+                "number": 47,
+                "string": False,
+                "inner": {"stuff": [1, 2, 3], "bool": 1},
+                "otter": {
+                    "integer": "7",
+                    "string": 1,
+                    "recursive": {"stuff": [1.0, 2.0, 3.0]},
+                },
+            }
+        )
+        self.assertEqual(Inner({"stuff": [1, 2, 3], "bool": True}), root.inner)
+        self.assertEqual("1", root.outer.string)
+        self.assertEqual(
+            {
+                "number": 47.0,
+                "string": "False",
+                "inner": {"stuff": [1.0, 2.0, 3.0], "bool": True},
+                "otter": {
+                    "integer": 7,
+                    "string": "1",
+                    "recursive": {"stuff": [1.0, 2.0, 3.0], "bool": None},
+                },
+            },
+            root.to_primitive(),
+        )
 
         copied = root.copy(deep=True)
         self.assertEqual(root, copied)
         copied.string = "True"
         self.assertNotEqual(root, copied)
-        self.assertEqual({
-            'string': 'True',
-            'inner': {'bool': True},
-            'otter': {'integer': 7, 'string': '1', 'recursive': {'bool': None}},
-        }, copied.serialize(role=ROLE_X))
-        self.assertEqual({
-            'number': 47.,
-            'string': 'True',
-            'inner': {'stuff': [1., 2., 3.]},
-            'otter': {'integer': 7, 'recursive': {'stuff': [1., 2., 3.]}},
-        }, copied.to_primitive(role=ROLE_Y))
-
-        with self.assertRaises(ValidationError) as e:
-            root.validate()
-        self.assertEqual({
-            'inner': {'stuff': ['Please provide no more than 2 items.']},
-            'otter': {
-                'recursive': {'bool': ['This field is required.'], 'stuff': ['Please provide no more than 2 items.']},
-                'string': [mock.ANY],
+        self.assertEqual(
+            {
+                "string": "True",
+                "inner": {"bool": True},
+                "otter": {"integer": 7, "string": "1", "recursive": {"bool": None}},
             },
-        }, e.exception.errors)
-        self.assertIn("must be one of", e.exception.errors["otter"]["string"][0])  # Exact message differs by version
+            copied.serialize(role=ROLE_X),
+        )
+        self.assertEqual(
+            {
+                "number": 47.0,
+                "string": "True",
+                "inner": {"stuff": [1.0, 2.0, 3.0]},
+                "otter": {"integer": 7, "recursive": {"stuff": [1.0, 2.0, 3.0]}},
+            },
+            copied.to_primitive(role=ROLE_Y),
+        )
 
-    @skipIf(schematics.__version__ < '2', "Schematics 1 reporting of list item errors is broken")
-    def test_list_index_error_key(self):
-        root = Root({
-            'string': 'abc',
-            'inner': {'stuff': [1, 9], 'bool': True},
-            'otter': None,
-        })
         with self.assertRaises(ValidationError) as e:
             root.validate()
-        self.assertEqual('inner: stuff: 1: Float value should be less than or equal to 7.0.', str(e.exception))
-        self.assertEqual({
-            'inner': {'stuff': {'1': ['Float value should be less than or equal to 7.0.']}}
-        }, e.exception.errors)
+        self.assertEqual(
+            {
+                "inner": {"stuff": ["Please provide no more than 2 items."]},
+                "otter": {
+                    "recursive": {
+                        "bool": ["This field is required."],
+                        "stuff": ["Please provide no more than 2 items."],
+                    },
+                    "string": [mock.ANY],
+                },
+            },
+            e.exception.errors,
+        )
+        self.assertIn(
+            "must be one of", e.exception.errors["otter"]["string"][0]
+        )  # Exact message differs by version
+
+    @skipIf(
+        schematics.__version__ < "2",
+        "Schematics 1 reporting of list item errors is broken",
+    )
+    def test_list_index_error_key(self):
+        root = Root(
+            {
+                "string": "abc",
+                "inner": {"stuff": [1, 9], "bool": True},
+                "otter": None,
+            }
+        )
+        with self.assertRaises(ValidationError) as e:
+            root.validate()
+        self.assertEqual(
+            "inner: stuff: 1: Float value should be less than or equal to 7.0.",
+            str(e.exception),
+        )
+        self.assertEqual(
+            {
+                "inner": {
+                    "stuff": {"1": ["Float value should be less than or equal to 7.0."]}
+                }
+            },
+            e.exception.errors,
+        )
 
     def test_configuration_error_no_explicit_field(self):
         class Bad(Model):
             worse: Outer = Outer
+
         with self.assertRaises(ConfigurationError) as e:
             Bad()
-        self.assertEqual("Field worse of Bad: Unrecognized field annotation Outer (may need an explicit Field)",
-                         str(e.exception))
+        self.assertEqual(
+            "Field worse of Bad: Unrecognized field annotation Outer (may need an explicit Field)",
+            str(e.exception),
+        )
 
     def test_configuration_error_mismatch(self):
         class Bad(Model):
             worse: Root = SchematicsModelField()
+
         with self.assertRaises(ConfigurationError) as e:
             Bad()
-        self.assertEqual("Field worse of Bad: SchematicsModelField cannot be used for annotation Root, "
-                         "should use ModelField", str(e.exception))
+        self.assertEqual(
+            "Field worse of Bad: SchematicsModelField cannot be used for annotation Root, "
+            "should use ModelField",
+            str(e.exception),
+        )
 
     def test_to_primitive_context(self):
-        root = Root({
-            'number': 47,
-            'string': False,
-            'inner': {'stuff': [1, 2, 3], 'bool': 1},
-            'otter': {'integer': '7', 'string': 1, 'recursive': {'stuff': [1., 2., 3.]}},
-        })
-        primitive_value = root.to_primitive(context={'private': True})
-        self.assertEqual(primitive_value['inner']['stuff'], '<hidden>')
+        root = Root(
+            {
+                "number": 47,
+                "string": False,
+                "inner": {"stuff": [1, 2, 3], "bool": 1},
+                "otter": {
+                    "integer": "7",
+                    "string": 1,
+                    "recursive": {"stuff": [1.0, 2.0, 3.0]},
+                },
+            }
+        )
+        primitive_value = root.to_primitive(context={"private": True})
+        self.assertEqual(primitive_value["inner"]["stuff"], "<hidden>")
+
+    def test_conversion_error_from_schematics(self):
+
+        with self.assertRaises(ConversionError) as ctx:
+            Root({"inner": {"bool": ""}})
+
+        self.assertEqual(
+            {"inner": {"bool": ["Must be either true or false."]}},
+            ctx.exception.errors,
+        )
+
+    def test_conversion_error_from_schematics_deep(self):
+        with self.assertRaises(ConversionError) as ctx:
+            Root(
+                {
+                    "number": 47,
+                    "string": False,
+                    "inner": {"stuff": [1, 2, 3], "bool": 1},
+                    "otter": {
+                        "integer": "7",
+                        "string": 1,
+                        "recursive": {"stuff": [1.0, 2.0, 3.0], "bool": ""},
+                    },
+                }
+            )
+        self.assertEqual(
+            {"otter": {"recursive": {"bool": ["Must be either true or false."]}}},
+            ctx.exception.errors,
+        )
+
+    def test_test(self):
+        from stereotype import (
+            Model,
+            ConversionError,
+            ModelField,
+            IntField,
+        )
+
+        class A(Model):
+            x: int = IntField()
+
+        class B(Model):
+            a: A = ModelField()
+
+        class C(Model):
+            b: B = ModelField
+
+        with self.assertRaises(ConversionError) as ctx:
+            C({"b": B({"a": A({"x": ""})})})
+
+        print()

--- a/tests/contrib/test_schematics.py
+++ b/tests/contrib/test_schematics.py
@@ -253,7 +253,6 @@ class TestSchematicsModelField(TestCase):
         self.assertEqual(primitive_value["inner"]["stuff"], "<hidden>")
 
     def test_conversion_error_from_schematics(self):
-
         with self.assertRaises(ConversionError) as ctx:
             Root({"inner": {"bool": ""}})
 


### PR DESCRIPTION
Added the catching of ConversionError from schematics in the convert of SchematicsModelField.

Had to take into consideration both versions of schematics, thus we check for the type of Error before trying to raise a new StereotypeConversionError.